### PR TITLE
Add .gitignore to maintain identical commits across branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore CODEOWNERS changes to maintain identical commit hashes across branches
+.github/CODEOWNERS


### PR DESCRIPTION
- Ignore only .github/CODEOWNERS to prevent divergent commits
- CODEOWNERS files are already in place for access control
- Future commits will have identical hashes across all branches